### PR TITLE
Add sdk config argument to command, and create local.properties for Android project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+config

--- a/bin/dryrun
+++ b/bin/dryrun
@@ -1,11 +1,28 @@
 #!/usr/bin/env ruby
 require 'bundler/setup'
 require 'dryrun'
+require 'optparse'
 
-# ARGUMENTS validation
-if ARGV.length != 1
-  puts "You need to provide the github URL"
-  exit 1
+config = false
+OptionParser.new do |opts|
+  opts.banner = 'Usage: dryrun [github_url]'
+
+  opts.on('-s', '--sdk SDK_PATH', 'Set Android SDK path (only for the first time)') do |v|
+    config = true
+    DryRun::Config.save(v)
+  end
+end.parse!
+
+unless config
+  if DryRun::Config.load.nil?
+    puts 'Wrong Android SDK path, please reconfig it'
+    exit 1
+  end
+
+  if ARGV.size == 1
+    DryRun::MainApp.initialize(ARGV[0])
+  else
+    puts 'You need to provide the github URL'
+    exit 1
+  end
 end
-
-DryRun::MainApp.initialize(ARGV[0])

--- a/lib/dryrun.rb
+++ b/lib/dryrun.rb
@@ -3,6 +3,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'dryrun/github'
 require 'dryrun/android_project'
+require 'dryrun/config'
 
 module DryRun
 

--- a/lib/dryrun.rb
+++ b/lib/dryrun.rb
@@ -10,7 +10,7 @@ module DryRun
   class MainApp
 
     def self.is_ANDROID_HOME_defined
-      return true
+      return !DryRun::Config.load.nil?
     end
 
 

--- a/lib/dryrun/android_project.rb
+++ b/lib/dryrun/android_project.rb
@@ -69,6 +69,16 @@ module DryRun
       return false, false
     end
 
+    def create_local_properties_if_necessary(sdk_dir)
+      file = "#{@base_path}/local.properties"
+      unless File.exist?(file)
+        File.open(file, 'w') do |f|
+          f.puts "sdk.dir=#{sdk_dir}"
+        end
+        puts "Created: '#{file}'"
+      end
+    end
+
     def get_uninstall_command
       "adb uninstall #{@package}"
     end

--- a/lib/dryrun/android_project.rb
+++ b/lib/dryrun/android_project.rb
@@ -40,6 +40,8 @@ module DryRun
         exit 1
       end
 
+      create_local_properties_if_necessary(DryRun::Config.load)
+
       builder = "gradle"
 
       if File.exist?("gradlew")

--- a/lib/dryrun/config.rb
+++ b/lib/dryrun/config.rb
@@ -1,0 +1,33 @@
+module DryRun
+  class Config
+    @@file = 'config'
+
+    class << self
+      def load
+        if File.exist?(@@file)
+          path = nil
+          File.open(@@file, 'r') do |f|
+            path = f.gets.chomp
+          end
+          puts 'Read from config:'
+          puts "ANDROID_HOME: #{path}"
+          return (File.exist?(path) ? path : nil)
+        else
+          fail('No config file is detected, please save it first.')
+        end
+      end
+
+      def save(path)
+        if File.exist?(path)
+          File.open(@@file, 'w') do |f|
+            f.puts path
+          end
+          puts 'Config file is saved.'
+        else
+          puts 'Invalid path, config is not saved.'
+          exit 1
+        end
+      end
+    end
+  end
+end

--- a/lib/dryrun/config.rb
+++ b/lib/dryrun/config.rb
@@ -9,8 +9,6 @@ module DryRun
           File.open(@@file, 'r') do |f|
             path = f.gets.chomp
           end
-          puts 'Read from config:'
-          puts "ANDROID_HOME: #{path}"
           return (File.exist?(path) ? path : nil)
         else
           fail('No config file is detected, please save it first.')

--- a/lib/dryrun/config.rb
+++ b/lib/dryrun/config.rb
@@ -1,6 +1,6 @@
 module DryRun
   class Config
-    @@file = 'config'
+    @@file = File.expand_path('../../', File.dirname(__FILE__)) + '/config'
 
     class << self
       def load

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'dryrun/config'
+
+describe '#config' do
+  context 'when load' do
+    it 'from a nonexistent file' do
+      allow(File).to receive(:exist?).with('config').and_return(false)
+      expect{ DryRun::Config.load() }.to raise_error(RuntimeError, 'No config file is detected, please save it first.')
+    end
+
+    it 'from an existing file but with invalid ANDROID_HOME' do
+      invalid_path = '/Users/abc/opt/android-sdk-macosx'
+      allow(File).to receive(:exist?).with('config').and_return(true)
+      allow(File).to receive(:exist?).with(invalid_path).and_return(false)
+      file = instance_double('File')
+      allow(File).to receive(:open).and_yield(file)
+      allow(file).to receive(:gets).and_return(invalid_path)
+
+      path = DryRun::Config.load()
+      expect(path).to be_nil
+    end
+
+    it 'from an existing file with valid ANDROID_HOME' do
+      expected = '/Users/abc/opt/android-sdk-macosx'
+      allow(File).to receive(:exist?).with('config').and_return(true)
+      allow(File).to receive(:exist?).with(expected).and_return(true)
+      file = instance_double('File')
+      allow(File).to receive(:open).and_yield(file)
+      allow(file).to receive(:gets).and_return(expected)
+
+      path = DryRun::Config.load()
+      expect(path).to eq(expected)
+    end
+  end
+
+  context 'when save' do
+    it 'a valid ANDROID_HOME' do
+      path = '/Users/abc/opt/android-sdk-macosx'
+      allow(File).to receive(:exist?).with(path).and_return(true)
+      file = instance_double('File')
+      allow(File).to receive(:open).and_yield(file)
+      expect(file).to receive(:puts).with(path)
+
+      DryRun::Config.save(path)
+    end
+
+    it 'an invalid ANDROID_HOME' do
+      path = '/Users/abc/opt/android-sdk-macosx'
+      allow(File).to receive(:exist?).with(path).and_return(false)
+
+      expect{ DryRun::Config.save(path) }.to raise_error(SystemExit)
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,15 +2,19 @@ require 'spec_helper'
 require 'dryrun/config'
 
 describe '#config' do
+  before(:each) do
+    @config_file = File.expand_path('..', File.dirname(__FILE__)) + '/config'
+  end
+
   context 'when load' do
     it 'from a nonexistent file' do
-      allow(File).to receive(:exist?).with('config').and_return(false)
+      allow(File).to receive(:exist?).with(@config_file).and_return(false)
       expect{ DryRun::Config.load() }.to raise_error(RuntimeError, 'No config file is detected, please save it first.')
     end
 
     it 'from an existing file but with invalid ANDROID_HOME' do
       invalid_path = '/Users/abc/opt/android-sdk-macosx'
-      allow(File).to receive(:exist?).with('config').and_return(true)
+      allow(File).to receive(:exist?).with(@config_file).and_return(true)
       allow(File).to receive(:exist?).with(invalid_path).and_return(false)
       file = instance_double('File')
       allow(File).to receive(:open).and_yield(file)
@@ -22,7 +26,7 @@ describe '#config' do
 
     it 'from an existing file with valid ANDROID_HOME' do
       expected = '/Users/abc/opt/android-sdk-macosx'
-      allow(File).to receive(:exist?).with('config').and_return(true)
+      allow(File).to receive(:exist?).with(@config_file).and_return(true)
       allow(File).to receive(:exist?).with(expected).and_return(true)
       file = instance_double('File')
       allow(File).to receive(:open).and_yield(file)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # suppress stdout during testing
+  config.before { allow($stdout).to receive(:puts) }
 end


### PR DESCRIPTION
Really nice project, brilliant idea!  (I'm an alfi user ;)

Ruby can't read _$ANDROID_HOME_ directly from system environment variables, it's painful.  And usually for Android projects, developers wouldn't check their **local.properties** (with hardcoded Android SDK path inside) into git.  Thus when using dryrun, I've encountered problems `java.lang.RuntimeException: SDK location not found. Define location with sdk.dir in the local.properties file or with an ANDROID_HOME environment variable.` even though I've set _$ANDROID_HOME_ to my system environment variables.

My solution is to have a local permanent config file to store Android SDK path info, which makes things easier.  So far we only need to store SDK path, so I didn't make the Config class too complicated (e.g. with key value pairs, save to a yaml, not necessary for now).

All tests are passed (and I've added some more).

Try this command and repo please:
`dryrun https://github.com/thyrlian/AwesomeValidation`
Before it didn't work, now it works perfectly.

And sorry, I don't have time to update the README file with latest command line usage, have to prepare for tomorrow's travel now, sorry ;)

Thank you so much for your time.
