### PR TITLE
Use the correct activity for the launcher activity

### DIFF
--- a/lib/dryrun/android_project.rb
+++ b/lib/dryrun/android_project.rb
@@ -189,7 +189,7 @@ module DryRun
         intent_filter = child.css('intent-filter')
 
         if intent_filter != nil and intent_filter.length != 0
-          return child.xpath("//activity").attr("android:name").last.value
+          return child.attr("android:name").value
         end
       end
       false


### PR DESCRIPTION
I created an issue for this here: #30.

For the project [Android-CleanArchitecture](https://github.com/android10/Android-CleanArchitecture) the launcher activity is not the activity that is launched when running the command:

`dryrun https://github.com/android10/Android-CleanArchitecture -m presentation`

It seems like using `xpath("//activity")` gets all the activities in the file and `last` returns us the last one.

The fix in this PR addresses the issue, but please review as I'm not familiar with xpath and don't know if that `xpath("//activity")` is necessary.

This fix allows dryrun to successfully launch the project above.
