### PR TITLE
Compare results from casecmp to integer

### DIFF
--- a/lib/dryrun.rb
+++ b/lib/dryrun.rb
@@ -94,7 +94,7 @@ module Dryrun
         input = ask "\n#{'Your Dryrun version is outdated, want to update?'.yellow} #{'[Y/n]:'.white}"
       end until %w(y n s).include?(input.downcase)
 
-      DryrunUtils.execute('gem update dryrun') if input.casecmp 'y'
+      DryrunUtils.execute('gem update dryrun') if input.casecmp('y') == 0
     end
 
     def pick_device


### PR DESCRIPTION
This fixes #113 
http://ruby-doc.org/core-2.4.0/String.html#method-i-casecmp