### PR TITLE
Update environment variable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dryrun (1.3.0)
+    dryrun (1.3.1)
       bundler
       colorize
       highline

--- a/README.md
+++ b/README.md
@@ -74,11 +74,7 @@ Options
 
 ## Notes
 
-Be aware that ANDROID_SDK_ROOT needs to be set with the adb path:
- - MAC -> ```ANDROID_SDK_ROOT=/usr/local/opt/android-sdk```
- - Linux -> ```ANDROID_SDK_ROOT=/usr/local/opt/android-sdk```
- - Windows -> ```ANDROID_SDK_ROOT="...sdk"```
-In Windows ANDROID_SDK_ROOT is not automatically created, see more in [here](https://github.com/facebook/react-native/blob/0.24-stable/docs/DevelopmentSetupAndroid.md#define-the-ANDROID_HOME-environment-variable)
+Be aware that `$ANDROID_SDK_ROOT` environment variable needs to be set. See more in [here](https://developer.android.com/studio/command-line/variables#set)
 
 Additionally, on windows in order to use git commands, the following path should be on the environment variable
   - ```...\Git\cmd ```

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Options
 
 ## Notes
 
-Be aware that ANDROID_HOME needs to be set with the adb path:
- - MAC -> ```ANDROID_HOME=/usr/local/opt/android-sdk```
- - Linux -> ```ANDROID_HOME=/usr/local/opt/android-sdk```
- - Windows -> ```ANDROID_HOME="...sdk"```
-In windows this ANDROID_HOME is not automatically created, see more in [here](https://github.com/facebook/react-native/blob/0.24-stable/docs/DevelopmentSetupAndroid.md#define-the-android_home-environment-variable)
+Be aware that ANDROID_SDK_ROOT needs to be set with the adb path:
+ - MAC -> ```ANDROID_SDK_ROOT=/usr/local/opt/android-sdk```
+ - Linux -> ```ANDROID_SDK_ROOT=/usr/local/opt/android-sdk```
+ - Windows -> ```ANDROID_SDK_ROOT="...sdk"```
+In Windows ANDROID_SDK_ROOT is not automatically created, see more in [here](https://github.com/facebook/react-native/blob/0.24-stable/docs/DevelopmentSetupAndroid.md#define-the-ANDROID_HOME-environment-variable)
 
 Additionally, on windows in order to use git commands, the following path should be on the environment variable
   - ```...\Git\cmd ```

--- a/lib/dryrun.rb
+++ b/lib/dryrun.rb
@@ -142,7 +142,7 @@ module Dryrun
       puts "Picked #{@device.name.to_s.green}" unless @device.nil?
     end
 
-    def ANDROID_SDK_ROOT_is_defined
+    def android_sdk_root_is_defined
       @sdk = if !Gem.win_platform?
                `echo $ANDROID_SDK_ROOT`.delete('\n')
              else
@@ -160,7 +160,7 @@ module Dryrun
     end
 
     def call
-      unless ANDROID_SDK_ROOT_is_defined
+      unless android_sdk_root_is_defined
         puts "\nWARNING: your #{'$ANDROID_SDK_ROOT'.yellow} is not defined\n"
         puts "\nhint: in your #{'~/.bashrc'.yellow} or #{'~/.bash_profile'.yellow}  add:\n  #{"export ANDROID_SDK_ROOT='/Users/cesarferreira/Library/Android/sdk/'".yellow}"
         puts "\nNow type #{'source ~/.bashrc'.yellow}\n\n"

--- a/lib/dryrun.rb
+++ b/lib/dryrun.rb
@@ -101,13 +101,13 @@ module Dryrun
       @device = nil
 
       if !Gem.win_platform?
-        @sdk = `echo $ANDROID_HOME`.delete("\n")
+        @sdk = `echo $ANDROID_SDK_ROOT`.delete("\n")
       else
-        @sdk = `echo %ANDROID_HOME%`.delete("\n")
+        @sdk = `echo %ANDROID_SDK_ROOT%`.delete("\n")
       end
 
       @sdk = 'adb' if @sdk.empty?
-        
+
       $sdk = @sdk
 
       puts 'Searching for devices...'.yellow
@@ -142,11 +142,11 @@ module Dryrun
       puts "Picked #{@device.name.to_s.green}" unless @device.nil?
     end
 
-    def android_home_is_defined
+    def ANDROID_SDK_ROOT_is_defined
       @sdk = if !Gem.win_platform?
-               `echo $ANDROID_HOME`.delete('\n')
+               `echo $ANDROID_SDK_ROOT`.delete('\n')
              else
-               `echo %ANDROID_HOME%`.delete('\n')
+               `echo %ANDROID_SDK_ROOT%`.delete('\n')
              end
       !@sdk.empty?
     end
@@ -160,9 +160,9 @@ module Dryrun
     end
 
     def call
-      unless android_home_is_defined
-        puts "\nWARNING: your #{'$ANDROID_HOME'.yellow} is not defined\n"
-        puts "\nhint: in your #{'~/.bashrc'.yellow} or #{'~/.bash_profile'.yellow}  add:\n  #{"export ANDROID_HOME='/Users/cesarferreira/Library/Android/sdk/'".yellow}"
+      unless ANDROID_SDK_ROOT_is_defined
+        puts "\nWARNING: your #{'$ANDROID_SDK_ROOT'.yellow} is not defined\n"
+        puts "\nhint: in your #{'~/.bashrc'.yellow} or #{'~/.bash_profile'.yellow}  add:\n  #{"export ANDROID_SDK_ROOT='/Users/cesarferreira/Library/Android/sdk/'".yellow}"
         puts "\nNow type #{'source ~/.bashrc'.yellow}\n\n"
         exit 1
       end

--- a/lib/dryrun/version.rb
+++ b/lib/dryrun/version.rb
@@ -1,3 +1,3 @@
 ﻿module Dryrun
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
As [per the official Android documentation](https://developer.android.com/studio/command-line/variables), the `$ANDROID_HOME` environment variable is now deprecated -> _ANDROID_HOME, which also points to the SDK installation directory, is deprecated_.

This PR simply replaces every occurrences of `$ANDROID_HOME` with `$ANDROID_SDK_ROOT`. It also modifies a bit the _Notes_ section to directly link to the official documentation.

Let me know